### PR TITLE
🛠 Fix JWT loading for shared view

### DIFF
--- a/tdrive/frontend/src/app/features/global/framework/local-storage-service.ts
+++ b/tdrive/frontend/src/app/features/global/framework/local-storage-service.ts
@@ -1,6 +1,11 @@
 export default class LocalStorage {
   static prefix = 'tdrive:';
 
+  //For shared views we will use another prefix
+  static setPrefix(prefix: string) {
+    LocalStorage.prefix = prefix;
+  }
+
   static setItem(key: string, value: unknown) {
     window.localStorage.setItem(`${LocalStorage.prefix}${key}`, JSON.stringify(value));
   }

--- a/tdrive/frontend/src/app/views/client/body/drive/index.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/index.tsx
@@ -17,9 +17,6 @@ export default ({
   context?: EmbedContext;
   inPublicSharing?: boolean;
 }) => {
-  //Preload applications mainly for shared view
-  useCompanyApplications();
-
   return (
     <>
       <SelectorModal />

--- a/tdrive/frontend/src/app/views/client/body/drive/modals/create/index.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/modals/create/index.tsx
@@ -1,3 +1,9 @@
+import Avatar from '@atoms/avatar';
+import A from '@atoms/link';
+import { Modal, ModalContent } from '@atoms/modal';
+import { Base } from '@atoms/text';
+import { useCompanyApplications } from '@features/applications/hooks/use-company-applications';
+import { Application } from '@features/applications/types/application';
 import { Transition } from '@headlessui/react';
 import {
   ChevronLeftIcon,
@@ -6,12 +12,6 @@ import {
   FolderDownloadIcon,
   LinkIcon,
 } from '@heroicons/react/outline';
-import Avatar from '@atoms/avatar';
-import A from '@atoms/link';
-import { Modal, ModalContent } from '@atoms/modal';
-import { Base } from '@atoms/text';
-import { useCompanyApplications } from '@features/applications/hooks/use-company-applications';
-import { Application } from '@features/applications/types/application';
 import { ReactNode } from 'react';
 import { atom, useRecoilState } from 'recoil';
 import { slideXTransition, slideXTransitionReverted } from 'src/utils/transitions';

--- a/tdrive/frontend/src/app/views/client/body/drive/shared.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/shared.tsx
@@ -23,9 +23,16 @@ import {
 import useRouterCompany from '../../../../features/router/hooks/use-router-company';
 import { CreateModalWithUploadZones } from '../../side-bar/actions';
 import { useCompanyApplications } from 'app/features/applications/hooks/use-company-applications';
+import LocalStorage from 'app/features/global/framework/local-storage-service';
 
 export default () => {
   const companyId = useRouterCompany();
+
+  //Create a different local storage for shared view
+  useEffect(() => {
+    LocalStorage.setPrefix('tdrive-shared:');
+    LocalStorage.clear();
+  }, []);
 
   const [state, setState] = useState({ group: { logo: '', name: '' } });
   useEffect(() => {


### PR DESCRIPTION
- Fix applications not loaded correctly because JWT is not set yet
- Fix JWT always required on load shared view
- Put JWT in an other store to not logout the connected user by replacing his JWT