### PR TITLE
Go to folder when searched (#68)

### DIFF
--- a/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
@@ -29,6 +29,7 @@ import { DriveCurrentFolderAtom } from '@views/client/body/drive/browser';
 import { useHistory } from 'react-router-dom';
 import RouterServices from '@features/router/services/router-service';
 import { useCurrentUser } from 'app/features/users/hooks/use-current-user';
+import useRouterCompany from 'app/features/router/hooks/use-router-company';
 
 export default (props: { driveItem: DriveItem & { user?: UserType }}) => {
   const history = useHistory();
@@ -47,6 +48,7 @@ export default (props: { driveItem: DriveItem & { user?: UserType }}) => {
 
   const { setOpen } = useSearchModal();
   const { open } = useDrivePreview();
+  const company = useRouterCompany();
 
   function openDoc(file: DriveItem){
     open(file);
@@ -56,7 +58,7 @@ export default (props: { driveItem: DriveItem & { user?: UserType }}) => {
   return (
     <div
       className="flex items-center p-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 rounded-md cursor-pointer"
-      onClick={() => openDoc(file)}
+      onClick={() => {history.push(RouterServices.generateRouteFromState({companyId: company, itemId: file.id})); open(file)}}
     >
       <FileResultMedia file={file} className="w-16 h-16 mr-3" />
       <div className="grow mr-3 overflow-hidden">

--- a/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
@@ -15,7 +15,6 @@ import {
 } from '@atoms/icons-colored';
 import * as Text from '@atoms/text';
 import { useCompanyApplications } from '@features/applications/hooks/use-company-applications';
-import useRouterCompany from '@features/router/hooks/use-router-company';
 import { DriveItem } from '@features/drive/types';
 import FileUploadAPIClient from '@features/files/api/file-upload-api-client';
 import { formatDate } from '@features/global/utils/format-date';

--- a/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
@@ -28,7 +28,7 @@ import { useDrivePreview } from '@features/drive/hooks/use-drive-preview';
 import Media from '@molecules/media';
 import { DriveCurrentFolderAtom } from '@views/client/body/drive/browser';
 
-export default (props: { driveItem: DriveItem & { user?: UserType } }) => {
+export default (props: { driveItem: DriveItem & { user?: UserType }, onClose: () => void }) => {
   const input = useRecoilValue(SearchInputState);
   const currentWorkspaceId = useRouterWorkspace();
   const companyApplications = useCompanyApplications();
@@ -45,10 +45,15 @@ export default (props: { driveItem: DriveItem & { user?: UserType } }) => {
   const { open: openViewer } = useFileViewerModal();
   const { open } = useDrivePreview();
 
+  function openDoc(file: DriveItem){
+    open(file);
+    if (file.is_directory) props.onClose();
+  }
+
   return (
     <div
       className="flex items-center p-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 rounded-md cursor-pointer"
-      onClick={() => open(file)}
+      onClick={() => openDoc(file)}
     >
       <FileResultMedia file={file} className="w-16 h-16 mr-3" />
       <div className="grow mr-3 overflow-hidden">
@@ -66,21 +71,23 @@ export default (props: { driveItem: DriveItem & { user?: UserType } }) => {
         </Text.Info>
         <ResultContext user={file.user} />
       </div>
-      <div
-        className="whitespace-nowrap"
-        onClick={e => {
-          e.preventDefault();
-          e.stopPropagation();
-        }}
-      >
-        <Button
-          theme="outline"
-          className="w-9 !p-0 flex items-center justify-center ml-2 rounded-full border-none"
-          onClick={() => onDriveItemDownloadClick(file)}
+      {!file.is_directory && (
+        <div
+          className="whitespace-nowrap"
+          onClick={e => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
         >
-          <DownloadIcon className="text-blue-500 w-6 h-6" />
-        </Button>
-      </div>
+          <Button
+            theme="outline"
+            className="w-9 !p-0 flex items-center justify-center ml-2 rounded-full border-none"
+            onClick={() => onDriveItemDownloadClick(file)}
+          >
+            <DownloadIcon className="text-blue-500 w-6 h-6" />
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
@@ -31,7 +31,7 @@ import { DriveCurrentFolderAtom } from '@views/client/body/drive/browser';
 import { useHistory } from 'react-router-dom';
 import RouterServices from '@features/router/services/router-service';
 
-export default (props: { driveItem: DriveItem & { user?: UserType } }) => {
+export default (props: { driveItem: DriveItem & { user?: UserType }, onClose: () => void }) => {
   const history = useHistory();
   const input = useRecoilValue(SearchInputState);
   const currentWorkspaceId = useRouterWorkspace();
@@ -48,12 +48,11 @@ export default (props: { driveItem: DriveItem & { user?: UserType } }) => {
   const { setOpen } = useSearchModal();
   const { open: openViewer } = useFileViewerModal();
   const { open } = useDrivePreview();
-  const company = useRouterCompany();
 
   return (
     <div
       className="flex items-center p-2 hover:bg-zinc-50 dark:hover:bg-zinc-800 rounded-md cursor-pointer"
-      onClick={() => {history.push(RouterServices.generateRouteFromState({companyId: company, itemId: file.id})); open(file)}}
+      onClick={() => open(file)}
     >
       <FileResultMedia file={file} className="w-16 h-16 mr-3" />
       <div className="grow mr-3 overflow-hidden">
@@ -71,21 +70,23 @@ export default (props: { driveItem: DriveItem & { user?: UserType } }) => {
         </Text.Info>
         <ResultContext user={file.user} />
       </div>
-      <div
-        className="whitespace-nowrap"
-        onClick={e => {
-          e.preventDefault();
-          e.stopPropagation();
-        }}
-      >
-        <Button
-          theme="outline"
-          className="w-9 !p-0 flex items-center justify-center ml-2 rounded-full border-none"
-          onClick={() => onDriveItemDownloadClick(file)}
+      {!file.is_directory && (
+        <div
+          className="whitespace-nowrap"
+          onClick={e => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
         >
-          <DownloadIcon className="text-blue-500 w-6 h-6" />
-        </Button>
-      </div>
+          <Button
+            theme="outline"
+            className="w-9 !p-0 flex items-center justify-center ml-2 rounded-full border-none"
+            onClick={() => onDriveItemDownloadClick(file)}
+          >
+            <DownloadIcon className="text-blue-500 w-6 h-6" />
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
@@ -1,7 +1,7 @@
 import { FolderIcon } from '@heroicons/react/solid';
 import Highlighter from 'react-highlight-words';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { onDriveItemDownloadClick, openDriveItem } from '../common';
+import { onDriveItemDownloadClick } from '../common';
 import ResultContext from './result-context';
 import { Button } from '@atoms/button/button';
 import { DownloadIcon } from '@atoms/icons-agnostic';
@@ -23,14 +23,12 @@ import useRouterWorkspace from '@features/router/hooks/use-router-workspace';
 import { useSearchModal } from '@features/search/hooks/use-search';
 import { SearchInputState } from '@features/search/state/search-input';
 import { UserType } from '@features/users/types/user';
-import { useFileViewerModal } from '@features/viewer/hooks/use-viewer';
 import { useDrivePreview } from '@features/drive/hooks/use-drive-preview';
 import Media from '@molecules/media';
 import { DriveCurrentFolderAtom } from '@views/client/body/drive/browser';
 import { useHistory } from 'react-router-dom';
-import RouterServices from '@features/router/services/router-service';
 
-export default (props: { driveItem: DriveItem & { user?: UserType }, onClose: () => void }) => {
+export default (props: { driveItem: DriveItem & { user?: UserType }}) => {
   const history = useHistory();
   const input = useRecoilValue(SearchInputState);
   const currentWorkspaceId = useRouterWorkspace();
@@ -45,12 +43,11 @@ export default (props: { driveItem: DriveItem & { user?: UserType }, onClose: ()
   const extension = name?.split('.').pop();
 
   const { setOpen } = useSearchModal();
-  const { open: openViewer } = useFileViewerModal();
   const { open } = useDrivePreview();
 
   function openDoc(file: DriveItem){
     open(file);
-    if (file.is_directory) props.onClose();
+    if (file.is_directory) setOpen(false);
   }
 
   return (

--- a/tdrive/frontend/src/app/components/search-popup/search-popup.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/search-popup.tsx
@@ -9,18 +9,16 @@ export default () => {
 
   return (
     <Modal open={open} onClose={() => setOpen(false)} className="sm:w-[80vw] sm:max-w-4xl">
-      <SearchBox onClose={() => setOpen(false)}/>
+      <SearchBox/>
     </Modal>
   );
 };
 
-const SearchBox = (props: {
-  onClose: () => void
-}) => {
+const SearchBox = () => {
   return (
     <ModalContent textCenter title={Languages.t('components.searchpopup.header_title')}>
       <SearchInput />
-      <SearchResultsIndex onClose={() => props.onClose()}/>
+      <SearchResultsIndex/>
     </ModalContent>
   );
 };

--- a/tdrive/frontend/src/app/components/search-popup/search-popup.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/search-popup.tsx
@@ -9,16 +9,18 @@ export default () => {
 
   return (
     <Modal open={open} onClose={() => setOpen(false)} className="sm:w-[80vw] sm:max-w-4xl">
-      <SearchBox />
+      <SearchBox onClose={() => setOpen(false)}/>
     </Modal>
   );
 };
 
-const SearchBox = () => {
+const SearchBox = (props: {
+  onClose: () => void
+}) => {
   return (
     <ModalContent textCenter title={Languages.t('components.searchpopup.header_title')}>
       <SearchInput />
-      <SearchResultsIndex />
+      <SearchResultsIndex onClose={() => props.onClose()}/>
     </ModalContent>
   );
 };

--- a/tdrive/frontend/src/app/components/search-popup/search-tabs.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/search-tabs.tsx
@@ -2,7 +2,9 @@
 import PerfectScrollbar from 'react-perfect-scrollbar';
 import SearchResulsDriveItems from './tabs/drive';
 
-export const SearchResultsIndex = () => {
+export const SearchResultsIndex = (props: {
+  onClose: () => void
+}) => {
   return (
     <>
       <PerfectScrollbar
@@ -11,7 +13,7 @@ export const SearchResultsIndex = () => {
         options={{ suppressScrollX: true, suppressScrollY: false }}
         component="div"
       >
-        <SearchResulsDriveItems />
+        <SearchResulsDriveItems onClose={() => props.onClose()}/>
       </PerfectScrollbar>
     </>
   );

--- a/tdrive/frontend/src/app/components/search-popup/search-tabs.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/search-tabs.tsx
@@ -2,9 +2,7 @@
 import PerfectScrollbar from 'react-perfect-scrollbar';
 import SearchResulsDriveItems from './tabs/drive';
 
-export const SearchResultsIndex = (props: {
-  onClose: () => void
-}) => {
+export const SearchResultsIndex = () => {
   return (
     <>
       <PerfectScrollbar
@@ -13,7 +11,7 @@ export const SearchResultsIndex = (props: {
         options={{ suppressScrollX: true, suppressScrollY: false }}
         component="div"
       >
-        <SearchResulsDriveItems onClose={() => props.onClose()}/>
+        <SearchResulsDriveItems/>
       </PerfectScrollbar>
     </>
   );

--- a/tdrive/frontend/src/app/components/search-popup/tabs/drive.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/tabs/drive.tsx
@@ -6,7 +6,7 @@ import { useRecoilValue } from 'recoil';
 import DriveItemResult from '../parts/drive-item-result';
 import NothingFound from '../parts/nothing-found';
 
-export default () => {
+export default (props: { onClose: () => void }) => {
   const input = useRecoilValue(SearchInputState);
   const isRecent = input?.query?.trim()?.length === 0;
   const { driveItems, loading } = useSearchDriveItems();
@@ -22,13 +22,13 @@ export default () => {
       )}
 
       <div className={'-mx-2'}>
-        <DriveItemsResults />
+        <DriveItemsResults onClose={() => props.onClose()}/>
       </div>
     </div>
   );
 };
 
-export const DriveItemsResults = (props: { max?: number }) => {
+export const DriveItemsResults = (props: { max?: number, onClose: () => void }) => {
   const { driveItems, loading } = useSearchDriveItems();
 
   if (driveItems.length === 0 && !loading) return <NothingFound />;
@@ -36,7 +36,7 @@ export const DriveItemsResults = (props: { max?: number }) => {
   return (
     <>
       {driveItems.slice(0, props?.max || driveItems.length).map(item => (
-        <DriveItemResult key={item.id} driveItem={item} />
+        <DriveItemResult key={item.id} driveItem={item} onClose={() => props.onClose()}/>
       ))}
     </>
   );

--- a/tdrive/frontend/src/app/components/search-popup/tabs/drive.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/tabs/drive.tsx
@@ -6,7 +6,7 @@ import { useRecoilValue } from 'recoil';
 import DriveItemResult from '../parts/drive-item-result';
 import NothingFound from '../parts/nothing-found';
 
-export default (props: { onClose: () => void }) => {
+export default () => {
   const input = useRecoilValue(SearchInputState);
   const isRecent = input?.query?.trim()?.length === 0;
   const { driveItems, loading } = useSearchDriveItems();
@@ -22,13 +22,13 @@ export default (props: { onClose: () => void }) => {
       )}
 
       <div className={'-mx-2'}>
-        <DriveItemsResults onClose={() => props.onClose()}/>
+        <DriveItemsResults/>
       </div>
     </div>
   );
 };
 
-export const DriveItemsResults = (props: { max?: number, onClose: () => void }) => {
+export const DriveItemsResults = (props: { max?: number}) => {
   const { driveItems, loading } = useSearchDriveItems();
 
   if (driveItems.length === 0 && !loading) return <NothingFound />;
@@ -36,7 +36,7 @@ export const DriveItemsResults = (props: { max?: number, onClose: () => void }) 
   return (
     <>
       {driveItems.slice(0, props?.max || driveItems.length).map(item => (
-        <DriveItemResult key={item.id} driveItem={item} onClose={() => props.onClose()}/>
+        <DriveItemResult key={item.id} driveItem={item}/>
       ))}
     </>
   );

--- a/tdrive/frontend/src/app/features/drive/hooks/use-drive-preview.ts
+++ b/tdrive/frontend/src/app/features/drive/hooks/use-drive-preview.ts
@@ -9,15 +9,21 @@ import { DriveItem } from '../types';
 import { useHistory } from 'react-router-dom';
 import RouterServices from '@features/router/services/router-service';
 import useRouterCompany from '@features/router/hooks/use-router-company';
+import { DriveCurrentFolderAtom } from 'app/views/client/body/drive/browser';
 
 export const useDrivePreviewModal = () => {
   const history = useHistory();
   const company = useRouterCompany();
   const [status, setStatus] = useRecoilState(DriveViewerState);
+  const [ parentId, setParentId ] = useRecoilState(
+    DriveCurrentFolderAtom({ initialFolderId: 'root' }),
+  );
 
   const open: (item: DriveItem) => void = (item: DriveItem) => {
     if (item.last_version_cache?.file_metadata?.source === 'internal') {
       setStatus({ item, loading: true });
+    } else if (item.is_directory){
+      setParentId(item.id);
     }
   };
 
@@ -89,3 +95,4 @@ export const useDrivePreviewDisplayData = () => {
 
   return { download, id, name, type, extension, size: status.details?.item.size };
 };
+

--- a/tdrive/frontend/src/app/features/drive/hooks/use-drive-preview.ts
+++ b/tdrive/frontend/src/app/features/drive/hooks/use-drive-preview.ts
@@ -6,13 +6,19 @@ import { useRecoilState } from 'recoil';
 import { DriveApiClient } from '../api-client/api-client';
 import { DriveViewerState } from '../state/viewer';
 import { DriveItem } from '../types';
+import { DriveCurrentFolderAtom } from 'app/views/client/body/drive/browser';
 
 export const useDrivePreviewModal = () => {
   const [status, setStatus] = useRecoilState(DriveViewerState);
+  const [ parentId, setParentId ] = useRecoilState(
+    DriveCurrentFolderAtom({ initialFolderId: 'root' }),
+  );
 
   const open: (item: DriveItem) => void = (item: DriveItem) => {
     if (item.last_version_cache?.file_metadata?.source === 'internal') {
       setStatus({ item, loading: true });
+    } else if (item.is_directory){
+      setParentId(item.id);
     }
   };
 
@@ -81,3 +87,4 @@ export const useDrivePreviewDisplayData = () => {
 
   return { download, id, name, type, extension, size: status.details?.item.size };
 };
+


### PR DESCRIPTION
The user is now able to go to a folder when he clicks on it in the search window.

Furthermore, the download button is no more present for folders:
![Download Button for folder](https://github.com/linagora/TDrive/assets/123820772/5aaa97e6-db32-4e84-9a5f-021083d3f863)
