### PR TITLE
:bug: disable definitive delete confirmation modal for

### DIFF
--- a/tdrive/frontend/src/app/views/client/body/drive/modals/confirm-delete/index.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/modals/confirm-delete/index.tsx
@@ -23,12 +23,15 @@ export const ConfirmDeleteModalAtom = atom<ConfirmDeleteModalType>({
 
 export const ConfirmDeleteModal = () => {
   const [state, setState] = useRecoilState(ConfirmDeleteModalAtom);
-
-  return (
-    <Modal open={state.open} onClose={() => setState({ ...state, open: false })}>
-      {!!state.items.length && <ConfirmDeleteModalContent items={state.items} />}
-    </Modal>
-  );
+    return (
+        <>
+            {state.items.length > 0 && (
+                <Modal open={state.open} onClose={() => setState({ ...state, open: false })}>
+                    <ConfirmDeleteModalContent items={state.items} />
+                </Modal>
+            )}
+        </>
+    )
 };
 
 const ConfirmDeleteModalContent = ({ items }: { items: DriveItem[] }) => {


### PR DESCRIPTION
When trash was empty and we click empty trash, a modal was triggered but without content. This patch just disable the modal activation when trash is empty.
