### PR TITLE
Frontend internal login cosmetic changes and minor bugs

### DIFF
--- a/tdrive/frontend/README.md
+++ b/tdrive/frontend/README.md
@@ -1,0 +1,10 @@
+# Twake Drive web frontend code
+
+## Development setup
+
+- Install node.js
+- `npm install --legacy-peer-deps`
+- `cp src/app/environment/environment.ts.dist.dev src/app/environment/environment.ts`
+- `npm run start`
+
+Needs a Twake Drive backend running and pointed to by that environment file.

--- a/tdrive/frontend/src/app/features/auth/login-service.ts
+++ b/tdrive/frontend/src/app/features/auth/login-service.ts
@@ -194,7 +194,9 @@ class Login extends Observable {
         }
         await this.updateUser();
       } catch (err) {
-        throw Error('Can not login');
+        this.login_loading = false;
+        this.login_error = true;
+        this.notify();
       } finally {
         this.logger.debug('Login process finished');
         Login.logInOngoing = false;

--- a/tdrive/frontend/src/app/features/users/services/current-user-service.ts
+++ b/tdrive/frontend/src/app/features/users/services/current-user-service.ts
@@ -46,15 +46,17 @@ class User {
     if (!name) {
       return 'Anonymous';
     }
+    // @author https://stackoverflow.com/a/17200679
+    const toNameCase = (str?: string) => (str || '').toLowerCase().replace(/(?<!\p{L})\p{L}(?=\p{L}{2})/gu, (m: string) => m.toUpperCase());
 
     if (user.deleted) {
       name = Languages.t('general.user.deleted');
     } else {
-      name = [user.first_name, user.last_name].filter(a => a).join(' ');
+      name = [user.first_name, user.last_name].filter(a => a).map(toNameCase).join(' ');
       name = name || user.username;
     }
 
-    return name.charAt(0).toUpperCase() + name.slice(1);
+    return name;
   }
 
   getThumbnail(user: UserType) {

--- a/tdrive/frontend/src/app/views/login/internal/signin/signin.jsx
+++ b/tdrive/frontend/src/app/views/login/internal/signin/signin.jsx
@@ -18,7 +18,7 @@ export default class Signin extends Component {
       username: '',
       email: LoginService.emailInit,
       password: '',
-      name: '',
+      lastName: '',
       firstName: '',
       phone: '',
       code: '',
@@ -105,8 +105,8 @@ export default class Signin extends Component {
               [],
               'Last name',
             )}
-            value={this.state.name}
-            onChange={evt => this.setState({ name: evt.target.value })}
+            value={this.state.lastName}
+            onChange={evt => this.setState({ lastName: evt.target.value })}
           />
 
           <br />

--- a/tdrive/frontend/src/app/views/login/internal/signin/signin.jsx
+++ b/tdrive/frontend/src/app/views/login/internal/signin/signin.jsx
@@ -37,8 +37,8 @@ export default class Signin extends Component {
     Languages.addListener(this);
   }
   componentDidMount() {
-    if (this.input) {
-      this.input.focus();
+    if (this.inputToFocusFirst) {
+      this.inputToFocusFirst.focus();
     }
   }
   componentWillUnmount() {
@@ -48,9 +48,9 @@ export default class Signin extends Component {
   componentDidUpdate(_prevProps, prevState) {
     if (
       (prevState.page === 1 && this.state.page === 2) ||
-      (prevState.page === 2 && this.state.page === 3 && this.input)
+      (prevState.page === 2 && this.state.page === 3 && this.inputToFocusFirst)
     ) {
-      if (this.input) this.input.focus();
+      if (this.inputToFocusFirst) this.inputToFocusFirst.focus();
     }
   }
   displayStep() {
@@ -75,6 +75,9 @@ export default class Signin extends Component {
 
           <Input
             id="first_name_create"
+            refInput={ref => {
+              this.inputToFocusFirst = ref;
+            }}
             className="bottom-margin medium full_width"
             onKeyDown={e => {
               if (e.keyCode === 13) {
@@ -91,9 +94,6 @@ export default class Signin extends Component {
           />
           <Input
             id="last_name_create"
-            refInput={ref => {
-              this.input = ref;
-            }}
             className="bottom-margin medium full_width"
             onKeyDown={e => {
               if (e.keyCode === 13) {


### PR DESCRIPTION
internal signup: Store last name (used wrong field name), focus the first field on load
internal login: When there's an error logging in; display it and permit a retry (used to stay in loading state)
Frontend header: user first name and last name capitalized if set; username left unchanged since it's reference