### PR TITLE
#397 move modal has dark text in dark mode (and tiny unrelated improvement to create directory dialog)

### DIFF
--- a/tdrive/frontend/public/index.html
+++ b/tdrive/frontend/public/index.html
@@ -24,6 +24,12 @@
         background: #FFFFFF;
       }
 
+      @media (prefers-color-scheme: dark) {
+        body, #root {
+          background: #2e3440; /* From tdrive/frontend/public/index.html - var(--nord0); */
+        }
+      }
+
       #root {
         z-index: 0;
       }

--- a/tdrive/frontend/src/app/views/client/body/drive/modals/create/create-folder.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/modals/create/create-folder.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
-import { CreateModalAtom } from '.';
+import { CreateModalAtom, CreateModalAtomType } from '.';
 import { Button } from '@atoms/button/button';
 import { Input } from '@atoms/input/input-text';
 import { Info } from '@atoms/text';
@@ -12,26 +12,44 @@ export const CreateFolder = () => {
   const [loading, _] = useState<boolean>(false);
   const [state, setState] = useRecoilState(CreateModalAtom);
   const { create } = useDriveActions();
+  const inputRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      const firstInput = inputRef.current && inputRef.current.querySelector("input") as HTMLInputElement;
+      if (firstInput)
+        firstInput.focus();
+    }, 100);
+  }, []);
+
+  const createFolderHandler = async () => {
+    await create({ name, parent_id: state.parent_id, is_directory: true }, {});
+    setState({ ...state, open: false });
+  }
 
   return (
     <>
       <Info>{ Languages.t('components.create_folder_modal.hint')}</Info>
-
-      <Input
-        disabled={loading}
-        placeholder={ Languages.t('components.create_folder_modal.placeholder')}
-        className="w-full mt-4"
-        onChange={(e: any) => setName(e.target.value)}
-      />
-
+      <div ref={inputRef}>
+        <Input
+          disabled={loading}
+          placeholder={ Languages.t('components.create_folder_modal.placeholder')}
+          className="w-full mt-4"
+          onKeyDown={(e: any) => {
+            if (e.keyCode === 13) {
+              e.preventDefault();
+              if (e.target.value)
+                createFolderHandler();
+            }
+          }}
+          onChange={(e: any) => setName(e.target.value)}
+        />
+      </div>
       <Button
         disabled={!name}
         loading={loading}
         className="mt-4 float-right"
-        onClick={async () => {
-          await create({ name, parent_id: state.parent_id, is_directory: true }, {});
-          setState({ ...state, open: false });
-        }}
+        onClick={createFolderHandler}
       >
         Create
       </Button>

--- a/tdrive/frontend/src/app/views/client/body/drive/modals/selector/index.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/modals/selector/index.tsx
@@ -85,7 +85,7 @@ const SelectorModalContent = (key:any,showfiles:boolean) => {
               setParentId(folder.id);
             }}
           >
-            <div className="grow flex flex-row items-center">
+            <div className="grow flex flex-row items-center dark:text-white">
               <FolderIcon className="h-5 w-5 shrink-0 text-blue-500 mr-2" />
               {folder.name}
             </div>
@@ -113,7 +113,7 @@ const SelectorModalContent = (key:any,showfiles:boolean) => {
             }
           }}
           >
-          <div className="grow flex flex-row items-center">
+          <div className="grow flex flex-row items-center dark:text-white">
             <DocumentIcon className="h-5 w-5 shrink-0 text-gray-400 mr-2" />
             {file.name}
           </div>


### PR DESCRIPTION
- Fix for #397 adding `dark:text-white` to text in move dialog
- In create folder dialog: autofocus input, accept enter key as confirmation