### PR TITLE
Use Github Actions for Docker build caches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,3 +85,6 @@ jobs:
             ${{ steps.meta.outputs.bake-file }}
           push: true
           targets: ${{ matrix.targets }}
+          set: |
+            _common.cache-to=type=gha,mode=max
+            _common.cache-from=type=gha

--- a/.github/workflows/publish_feature.yml
+++ b/.github/workflows/publish_feature.yml
@@ -1,4 +1,4 @@
-name: Publish Feature Brunch
+name: Publish Feature Branch
 
 on:
   push:
@@ -55,7 +55,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           tags: |
-            ${{ github.head_ref || github.ref_name }} 
+            ${{ github.head_ref || github.ref_name }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -79,3 +79,6 @@ jobs:
             ${{ steps.meta.outputs.bake-file }}
           push: true
           targets: ${{ matrix.targets }}
+          set: |
+            _common.cache-to=type=gha,mode=max
+            _common.cache-from=type=gha


### PR DESCRIPTION
Use [buildx Github Action cache integration](https://github.com/moby/buildkit#github-actions-cache-experimental) to reduce build time.