### PR TITLE
🐛 don't include deleted items in archives

### DIFF
--- a/tdrive/backend/node/src/services/documents/utils.ts
+++ b/tdrive/backend/node/src/services/documents/utils.ts
@@ -341,6 +341,8 @@ export const addDriveItemToArchive = async (
     throw Error(`Item '${JSON.stringify(itemPK)}' not found`);
   }
 
+  if (item.is_in_trash) return;
+
   if (!item.is_directory) {
     const file_id = item.last_version_cache.file_metadata.external_id;
     const file = await gr.services.files.download(file_id, context);


### PR DESCRIPTION
Pending a 401 bug on local login and zip downloads:

- A shares a folder publicly
  - A adds file `abc`
- anonymous uses link to upload file `def`
- A deletes `def`
- A downloads folder as zip file
- Zip file includes `def` - but here's the kicker: it shouldn't because it was deleted in step 2 (or 3 if you count sub-steps too)