### PR TITLE
Give a more appropriate default file name for zip file downloads #600

### DIFF
--- a/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
+++ b/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
@@ -479,7 +479,7 @@ export class DocumentsController {
       ids = items.children.map(item => item.id);
     }
 
-    if (isDirectory) {
+    if (isDirectory === true) {
       const items = await globalResolver.services.documents.documents.get(ids[0], context, true);
       ids = items.children.map(item => item.id);
     }

--- a/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
+++ b/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
@@ -486,6 +486,7 @@ export class DocumentsController {
 
     try {
       const archive = await globalResolver.services.documents.documents.createZip(ids, context);
+      reply.raw.setHeader("content-disposition", 'attachment; filename="twake_drive.zip"');
 
       archive.on("finish", () => {
         reply.status(200);

--- a/tdrive/frontend/src/app/features/drive/hooks/use-drive-actions.tsx
+++ b/tdrive/frontend/src/app/features/drive/hooks/use-drive-actions.tsx
@@ -99,7 +99,7 @@ export const useDriveActions = () => {
   );
 
   const downloadZip = useCallback(
-    async (ids: string[], isDirectory?: boolean) => {
+    async (ids: string[], isDirectory = false) => {
       try {
         const url = await DriveApiClient.getDownloadZipUrl(companyId, ids, isDirectory);
         (window as any).open(url, '_blank').focus();


### PR DESCRIPTION
Files are now `twake_drive.zip` (a more complicated scheme could be come up with, use ai, number of files, types, etc, but it's better than nothing for now).

Note: Includes changes from PR #619 