### PR TITLE
Deleted extra character in `twakedrive/tdrive-nextcloud-migration` image name

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -50,7 +50,7 @@ target "nextcloud-migration" {
   inherits = ["_common"]
   dockerfile = "docker/tdrive-nextcloud-migration/Dockerfile"
   tags = concat(
-    generate_tags("docker.io/twakedrive˚/tdrive-nextcloud-migration", target.docker-metadata-action.tags),
+    generate_tags("docker.io/twakedrive/tdrive-nextcloud-migration", target.docker-metadata-action.tags),
     generate_tags("docker-registry.linagora.com/tdrive/tdrive-nextcloud-migration", target.docker-metadata-action.tags),
   )
 }


### PR DESCRIPTION
Deleted `˚` in docker image name, which breaks docker builds