### PR TITLE
🐛 Fix URL encoded filename on download

### DIFF
--- a/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
+++ b/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
@@ -24,6 +24,7 @@ import {
 import { DriveFileDTO } from "../dto/drive-file-dto";
 import { DriveFileDTOBuilder } from "../../services/drive-file-dto-builder";
 import config from "config";
+import { formatAttachmentContentDispositionHeader } from "../../../files/utils";
 
 export class DocumentsController {
   private driveFileDTOBuilder = new DriveFileDTOBuilder();
@@ -427,12 +428,8 @@ export class DocumentsController {
         return response;
       } else if (archiveOrFile.file) {
         const data = archiveOrFile.file;
-        const filename = encodeURIComponent(data.name.replace(/[^\p{L}0-9 _.-]/gu, ""));
 
-        response.header(
-          "Content-Disposition",
-          `attachment; filename="${filename}"; filename*=UTF-8''${filename}`,
-        );
+        response.header("Content-Disposition", formatAttachmentContentDispositionHeader(data.name));
 
         if (data.size) response.header("Content-Length", data.size);
         response.type(data.mime);
@@ -486,7 +483,10 @@ export class DocumentsController {
 
     try {
       const archive = await globalResolver.services.documents.documents.createZip(ids, context);
-      reply.raw.setHeader("content-disposition", 'attachment; filename="twake_drive.zip"');
+      reply.raw.setHeader(
+        "content-disposition",
+        formatAttachmentContentDispositionHeader("twake_drive.zip"),
+      );
 
       archive.on("finish", () => {
         reply.status(200);

--- a/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
+++ b/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
@@ -429,7 +429,11 @@ export class DocumentsController {
         const data = archiveOrFile.file;
         const filename = encodeURIComponent(data.name.replace(/[^\p{L}0-9 _.-]/gu, ""));
 
-        response.header("Content-disposition", `attachment; filename="${filename}"`);
+        response.header(
+          "Content-Disposition",
+          `attachment; filename="${filename}"; filename*=UTF-8''${filename}`,
+        );
+
         if (data.size) response.header("Content-Length", data.size);
         response.type(data.mime);
         return response.send(data.file);

--- a/tdrive/backend/node/src/services/files/utils.ts
+++ b/tdrive/backend/node/src/services/files/utils.ts
@@ -22,3 +22,12 @@ export const fileIsMedia = (file: Partial<File>): boolean => {
     file.metadata?.mime?.startsWith("image/")
   );
 };
+
+/**
+ * Generate RFC 5987 UTF-8 encoding compliant header value for `Content-Disposition`
+ * to make a browser download a reponse to a file with the provided name
+ */
+export const formatAttachmentContentDispositionHeader = (filename: string) => {
+  const encoded = encodeURIComponent(filename.replace(/[^\p{L}0-9 _.-]/gu, ""));
+  return `attachment; filename="${encoded}"; filename*=UTF-8''${encoded}`;
+};

--- a/tdrive/backend/node/src/services/files/web/controllers/files.ts
+++ b/tdrive/backend/node/src/services/files/web/controllers/files.ts
@@ -5,6 +5,7 @@ import { CompanyExecutionContext } from "../types";
 import { UploadOptions } from "../../types";
 import { PublicFile } from "../../entities/file";
 import gr from "../../../global-resolver";
+import { formatAttachmentContentDispositionHeader } from "../../utils";
 
 export class FileController {
   async save(
@@ -47,12 +48,7 @@ export class FileController {
     const params = request.params;
     try {
       const data = await gr.services.files.download(params.id, context);
-      const filename = data.name.replace(/[^a-zA-Z0-9 -_.]/g, "");
-
-      response.header(
-        "Content-Disposition",
-        `attachment; filename="${filename}"; filename*=UTF-8''${filename}`,
-      );
+      response.header("Content-Disposition", formatAttachmentContentDispositionHeader(data.name));
 
       if (data.size) response.header("Content-Length", data.size);
       response.type(data.mime);

--- a/tdrive/backend/node/src/services/files/web/controllers/files.ts
+++ b/tdrive/backend/node/src/services/files/web/controllers/files.ts
@@ -49,7 +49,11 @@ export class FileController {
       const data = await gr.services.files.download(params.id, context);
       const filename = data.name.replace(/[^a-zA-Z0-9 -_.]/g, "");
 
-      response.header("Content-disposition", `attachment; filename="${filename}"`);
+      response.header(
+        "Content-Disposition",
+        `attachment; filename="${filename}"; filename*=UTF-8''${filename}`,
+      );
+
       if (data.size) response.header("Content-Length", data.size);
       response.type(data.mime);
       return response.send(data.file);


### PR DESCRIPTION
The issue originated on **MacOS** platforms when testing on Safari and Opera browsers.

## Bug description
When users uploaded files with non-ASCII characters in their names (e.g., files with Russian characters), the filenames would become distorted upon download. This is a browser-related limitation where non-ASCII characters are not properly handled in the Content-Disposition header during file download.

Platform: MacOS, Browsers: Safari, Opera

## Fix description
We resolved this by updating the Content-Disposition header. The key here is the filename*= attribute. This is based on RFC 5987, which allows us to specify an encoding (in this case, UTF-8) to handle filenames that include special characters. Without filename*=, many browsers fall back to ASCII, causing filenames with non-ASCII characters to display incorrectly. By using this syntax, we ensure consistent handling of filenames across browsers and platforms.

This fix ensures proper cross-browser support, particularly when dealing with international file names or special characters, something that is crucial for user experience in globalized environments.