### PR TITLE
🐛 oo-connector: do not crash if getting a health request before onlyoffice awake

### DIFF
--- a/tdrive/connectors/onlyoffice-connector/src/services/forgotten-processor.service.ts
+++ b/tdrive/connectors/onlyoffice-connector/src/services/forgotten-processor.service.ts
@@ -28,14 +28,18 @@ class ForgottenProcessor implements IHealthProvider {
   }
 
   public async getHealthData() {
-    const keys = await onlyofficeService.getForgottenList();
-    return {
-      forgotten: {
-        timeSinceLastStartS: this.lastStart ? ~~((new Date().getTime() - this.lastStart) / 1000) : -1,
-        count: keys?.length ?? 0,
-        locks: this.forgottenSynchroniser.getWorstStats(),
-      },
-    };
+    try {
+      const keys = await onlyofficeService.getForgottenList();
+      return {
+        forgotten: {
+          timeSinceLastStartS: this.lastStart ? ~~((new Date().getTime() - this.lastStart) / 1000) : -1,
+          count: keys?.length ?? 0,
+          locks: this.forgottenSynchroniser.getWorstStats(),
+        },
+      };
+    } catch (e) {
+      return { forgotten: 'Error' };
+    }
   }
 
   /**


### PR DESCRIPTION
because of my bug in the health endpoint, requesting it before onlyoffice is functioning caused the connector to crash