### PR TITLE
onlyoffice filename corrupted after editing

### DIFF
--- a/tdrive/backend/node/src/cli/cmds/editing_session_cmds/list.ts
+++ b/tdrive/backend/node/src/cli/cmds/editing_session_cmds/list.ts
@@ -94,6 +94,10 @@ async function report(platform: TdrivePlatform, args: ListArguments) {
         `    - ${formatTS(version.date_added)} by ${await formatUser(version.creator_id)}`,
       );
       console.error(`        - id:          ${version.id}`);
+      if (dfile.name != version.filename)
+        console.error(`        - filename:    ${JSON.stringify(version.filename)}`);
+      if (dfile.name != version.file_metadata.name)
+        console.error(`        - meta.name:   ${JSON.stringify(version.file_metadata.name)}`);
       console.error(
         `        - size:        ${version.file_metadata.size} (${
           version.file_metadata.size > previousSize ? "+" : ""

--- a/tdrive/backend/node/src/services/documents/services/index.ts
+++ b/tdrive/backend/node/src/services/documents/services/index.ts
@@ -1148,7 +1148,15 @@ export class DocumentsService {
     }
 
     if (file) {
-      const fileEntity = await globalResolver.services.files.save(null, file, options, context);
+      const fileEntity = await globalResolver.services.files.save(
+        null,
+        file,
+        {
+          ...options,
+          filename: options.filename ?? driveFile.name,
+        },
+        context,
+      );
 
       await globalResolver.services.documents.documents.createVersion(
         driveFile.id,
@@ -1158,6 +1166,7 @@ export class DocumentsService {
           file_metadata: {
             external_id: fileEntity.id,
             source: "internal",
+            name: file.filename ?? driveFile.name,
           },
         },
         context,
@@ -1184,8 +1193,14 @@ export class DocumentsService {
             )}`,
           );
       } catch (error) {
-        logger.error({ error: `${error}` }, "Failed to cancel editing Drive item");
-        CrudException.throwMe(error, new CrudException("Failed to cancel editing Drive item", 500));
+        logger.error(
+          { error: `${error}` },
+          `Failed to ${keepEditing ? "update" : "end"} editing Drive item`,
+        );
+        CrudException.throwMe(
+          error,
+          new CrudException(`Failed to ${keepEditing ? "update" : "end"} editing Drive item`, 500),
+        );
       }
     }
   };

--- a/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
+++ b/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
@@ -422,7 +422,7 @@ export class DocumentsController {
         totalChunks: parseInt(q.resumableTotalChunks || q.total_chunks) || 1,
         totalSize: parseInt(q.resumableTotalSize || q.total_size) || 0,
         chunkNumber: parseInt(q.resumableChunkNumber || q.chunk_number) || 1,
-        filename: q.resumableFilename || q.filename || file?.filename || undefined,
+        filename: q.filename || undefined,
         type: q.resumableType || q.type || file?.mimetype || undefined,
         waitForThumbnail: !!q.thumbnail_sync,
         ignoreThumbnails: false,


### PR DESCRIPTION
Fix #683 

Filename handling is going to be worth a major refactor