### PR TITLE
🐛 Fix size 0 (number) transformed into empty string

### DIFF
--- a/tdrive/backend/node/src/core/platform/services/database/services/orm/connectors/mongodb/typeTransforms.ts
+++ b/tdrive/backend/node/src/core/platform/services/database/services/orm/connectors/mongodb/typeTransforms.ts
@@ -63,6 +63,10 @@ export const transformValueToDbString = (
     return +v;
   }
 
+  if (type === "number") {
+    if (v === 0) return v;
+  }
+
   return v || "";
 };
 


### PR DESCRIPTION
## Description
The ORM connector for mongo is storing size for empty folders supposedly 0 as empty string. This PR solves it by accounting for the "number" type when transforming values before insertion into the db/collection. 

## Related Issue
https://github.com/linagora/twake-drive/issues/704