### PR TITLE
Removed 'version' from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   mongo:
     container_name: mongo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Users will get a warning that 'version' is obsolete in Docker compose. Remove version from docker-compose.yml since it's obsolete and shouldn't be used.

## Related Issue
https://github.com/linagora/twake-drive/issues/726

## Motivation and Context


## How Has This Been Tested?
Removing the 'version' does not have any impact and removes the warning message.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added the Signed-off-by statement at the end of my commit message.
