### PR TITLE
🩹 back: tolerate extraneous `/`s in env vars

### DIFF
--- a/tdrive/backend/node/src/core/platform/services/email-pusher/index.ts
+++ b/tdrive/backend/node/src/core/platform/services/email-pusher/index.ts
@@ -16,6 +16,7 @@ import path from "path";
 import { existsSync } from "fs";
 import axios from "axios";
 import short, { Translator } from "short-uuid";
+import { joinURL } from "../../../../utils/urls";
 
 export default class EmailPusherClass
   extends TdriveService<EmailPusherAPI>
@@ -86,7 +87,14 @@ export default class EmailPusherClass
       const encodedCompanyId = translator.fromUUID(data.notifications[0].item.company_id);
       const encodedItemId = translator.fromUUID(data.notifications[0].item.id);
       const previewType = data.notifications[0].item.is_directory ? "d" : "preview";
-      const encodedUrl = `${this.platformUrl}/client/${encodedCompanyId}/v/shared_with_me/${previewType}/${encodedItemId}`;
+      const encodedUrl = joinURL([
+        this.platformUrl,
+        "client",
+        encodedCompanyId,
+        "v/shared_with_me",
+        previewType,
+        encodedItemId,
+      ]);
 
       if (!existsSync(templatePath)) {
         throw Error(`template not found: ${templatePath}`);

--- a/tdrive/backend/node/src/utils/urls.ts
+++ b/tdrive/backend/node/src/utils/urls.ts
@@ -1,0 +1,17 @@
+/** Suitable type for query arguments */
+export type QueryParams = { [key: string]: string | number };
+
+/**
+ * Compose a URL removing and adding slashes and query parameters as warranted.
+ * Does not encode paths.
+ */
+export function joinURL(path: string[], params?: QueryParams) {
+  let joinedPath = path.map(x => x.replace(/(?:^\/+)|(?:\/+$)/g, "")).join("/");
+  if (path[path.length - 1].endsWith("/")) joinedPath += "/";
+  const paramEntries = Object.entries(params || {}).filter(
+    ([, value]) => value !== undefined && value !== null,
+  );
+  if (paramEntries.length === 0) return joinedPath;
+  const query = paramEntries.map(p => p.map(encodeURIComponent).join("=")).join("&");
+  return joinedPath + (joinedPath.indexOf("?") > -1 ? "&" : "?") + query;
+}


### PR DESCRIPTION
Prevent further config issues to mitigate internal issue reference 3842 