### PR TITLE
🔊 oo-connector: output JSON logs in production

### DIFF
--- a/tdrive/connectors/onlyoffice-connector/src/config/index.ts
+++ b/tdrive/connectors/onlyoffice-connector/src/config/index.ts
@@ -16,6 +16,8 @@ export const {
   OOCONNECTOR_HEALTH_SECRET,
 } = process.env;
 
+export const isProductionEnv = (NODE_ENV ?? '').toLocaleLowerCase().trim() === 'production';
+
 const secs = 1000,
   mins = 60 * secs;
 

--- a/tdrive/connectors/onlyoffice-connector/src/lib/logger.ts
+++ b/tdrive/connectors/onlyoffice-connector/src/lib/logger.ts
@@ -1,5 +1,7 @@
 import { Logger } from 'tslog';
+import { isProductionEnv } from '../config';
 
 export default new Logger({
   name: 'twake-onlyoffice-plugin',
+  type: isProductionEnv ? 'json' : 'pretty',
 });


### PR DESCRIPTION
if NODE_ENV=production, then log in JSON format