### PR TITLE
Remove redundant Quota API calls

### DIFF
--- a/tdrive/frontend/src/app/features/users/hooks/use-user-quota.ts
+++ b/tdrive/frontend/src/app/features/users/hooks/use-user-quota.ts
@@ -37,10 +37,5 @@ export const useUserQuota = () => {
     setQuota(data)
   },  []);
 
-  useEffect(() => {
-    getQuota();
-  }, []);
-
-
   return { quota, getQuota };
 };

--- a/tdrive/frontend/src/app/views/client/common/disk-usage.tsx
+++ b/tdrive/frontend/src/app/views/client/common/disk-usage.tsx
@@ -16,7 +16,12 @@ const DiskUsage = () => {
   const [usedBytes, setUsedBytes] = useState(0);
   const [totalBytes, setTotalBytes] = useState(0);
 
-  const { quota } = useUserQuota()
+  const { quota, getQuota } = useUserQuota();
+
+  useEffect(() => {
+    getQuota();
+  }, [])
+
   useEffect(() => {
     if (FeatureTogglesService.isActiveFeatureName(FeatureNames.COMPANY_USER_QUOTA)) {
       setUsed(Math.round(quota.used / quota.total * 100))


### PR DESCRIPTION
Remove redundant Quota API calls

## Description
Whenever the `useUserQuota` hook is used, it automatically calls the Quota API. To fix this, we can remove the API call from the hook. Instead, the `getQuota` function from the hook can be used directly in the components or other hooks that rely on `useUserQuota`.

## Related Issue
[758](https://github.com/linagora/twake-drive/issues/758)

## Motivation and Context
Reduce multiple unnecessary API calls to fetch `quota` are being triggered in the frontend

## How Has This Been Tested?
The changes were tested using the browser's network tab in the developer tools. After reloading the page multiple times, it was confirmed that only one request is made to the Quota API per page load, ensuring the issue is resolved.

## Screenshots (if appropriate):
![CleanShot 2024-12-03 at 14 53 38@2x](https://github.com/user-attachments/assets/751f58ba-bff4-4669-ba59-c5db40ab9ad2)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added the Signed-off-by statement at the end of my commit message.
