### PR TITLE
🔊 back: use sub loggers for platform and message queue logging

### DIFF
--- a/tdrive/backend/node/src/core/platform/framework/api/component.ts
+++ b/tdrive/backend/node/src/core/platform/framework/api/component.ts
@@ -3,7 +3,7 @@ import { TdriveService } from "./service";
 import { TdriveServiceProvider } from "./service-provider";
 import { ServiceDefinition } from "./service-definition";
 import { TdriveServiceState } from "./service-state";
-import { logger } from "../logger";
+import { platformLogger } from "../logger";
 
 export class TdriveComponent {
   instance: TdriveService<TdriveServiceProvider>;
@@ -38,7 +38,7 @@ export class TdriveComponent {
     recursionDepth?: number,
   ): Promise<void> {
     if (recursionDepth > 10) {
-      logger.error("Maximum recursion depth exceeded (will exit process)");
+      platformLogger.error("Maximum recursion depth exceeded (will exit process)");
       process.exit(1);
     }
 
@@ -50,10 +50,10 @@ export class TdriveComponent {
       for (const component of this.components) {
         await component.switchToState(state, (recursionDepth || 0) + 1);
       }
-      logger.info(`Children of ${this.name} are all in ${state} state`);
-      logger.info(this.getStateTree());
+      platformLogger.info(`Children of ${this.name} are all in ${state} state`);
+      platformLogger.info(this.getStateTree());
     } else {
-      logger.info(`${this.name} does not have children`);
+      platformLogger.info(`${this.name} does not have children`);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tdrive/backend/node/src/core/platform/framework/api/service.ts
+++ b/tdrive/backend/node/src/core/platform/framework/api/service.ts
@@ -6,7 +6,7 @@ import { TdriveServiceConfiguration } from "./service-configuration";
 import { TdriveContext } from "./context";
 import { TdriveServiceOptions } from "./service-options";
 import { CONSUMES_METADATA, PREFIX_METADATA } from "./constants";
-import { getLogger, logger } from "../logger";
+import { getLogger, platformLogger } from "../logger";
 import { TdriveLogger } from "..";
 
 const pendingServices: any = {};
@@ -39,23 +39,23 @@ export abstract class TdriveService<T extends TdriveServiceProvider>
 
   async init(): Promise<this> {
     if (this.state.value !== TdriveServiceState.Ready) {
-      logger.info("Service %s is already initialized", this.name);
+      platformLogger.info("Service %s is already initialized", this.name);
       return this;
     }
 
     try {
-      logger.info("Initializing service %s", this.name);
+      platformLogger.info("Initializing service %s", this.name);
       pendingServices[this.name] = true;
       this.state.next(TdriveServiceState.Initializing);
       await this.doInit();
       this.state.next(TdriveServiceState.Initialized);
-      logger.info("Service %s is initialized", this.name);
+      platformLogger.info("Service %s is initialized", this.name);
       delete pendingServices[this.name];
-      logger.info("Pending services: %s", JSON.stringify(Object.keys(pendingServices)));
+      platformLogger.info("Pending services: %s", JSON.stringify(Object.keys(pendingServices)));
       return this;
     } catch (err) {
-      logger.error("Error while initializing service %s", this.name);
-      logger.error(err);
+      platformLogger.error("Error while initializing service %s", this.name);
+      platformLogger.error(err);
       this.state.error(new Error(`Error while initializing service ${this.name}`));
 
       throw err;
@@ -75,21 +75,21 @@ export abstract class TdriveService<T extends TdriveServiceProvider>
       this.state.value === TdriveServiceState.Starting ||
       this.state.value === TdriveServiceState.Started
     ) {
-      logger.info("Service %s is already started", this.name);
+      platformLogger.info("Service %s is already started", this.name);
       return this;
     }
 
     try {
-      logger.info("Starting service %s", this.name);
+      platformLogger.info("Starting service %s", this.name);
       this.state.next(TdriveServiceState.Starting);
       await this.doStart();
       this.state.next(TdriveServiceState.Started);
-      logger.info("Service %s is started", this.name);
+      platformLogger.info("Service %s is started", this.name);
 
       return this;
     } catch (err) {
-      logger.error("Error while starting service %s", this.name, err);
-      logger.error(err);
+      platformLogger.error("Error while starting service %s", this.name, err);
+      platformLogger.error(err);
       this.state.error(new Error(`Error while starting service ${this.name}`));
 
       throw err;
@@ -101,26 +101,26 @@ export abstract class TdriveService<T extends TdriveServiceProvider>
       this.state.value === TdriveServiceState.Stopping ||
       this.state.value === TdriveServiceState.Stopped
     ) {
-      logger.info("Service %s is already stopped", this.name);
+      platformLogger.info("Service %s is already stopped", this.name);
       return this;
     }
 
     if (this.state.value !== TdriveServiceState.Started) {
-      logger.info("Service %s can not be stopped until started", this.name);
+      platformLogger.info("Service %s can not be stopped until started", this.name);
       return this;
     }
 
     try {
-      logger.info("Stopping service %s", this.name);
+      platformLogger.info("Stopping service %s", this.name);
       this.state.next(TdriveServiceState.Stopping);
       await this.doStop();
       this.state.next(TdriveServiceState.Stopped);
-      logger.info("Service %s is stopped", this.name);
+      platformLogger.info("Service %s is stopped", this.name);
 
       return this;
     } catch (err) {
-      logger.error("Error while stopping service %s", this.name, err);
-      logger.error(err);
+      platformLogger.error("Error while stopping service %s", this.name, err);
+      platformLogger.error(err);
       this.state.error(new Error(`Error while stopping service ${this.name}`));
 
       throw err;

--- a/tdrive/backend/node/src/core/platform/framework/logger.ts
+++ b/tdrive/backend/node/src/core/platform/framework/logger.ts
@@ -23,3 +23,7 @@ export const logger = pino({
 
 export const getLogger = (name?: string): TdriveLogger =>
   logger.child({ name: `tdrive${name ? "." + name : ""}` });
+
+export const platformLogger = getLogger("platform");
+
+export const messageQueueLogger = getLogger("message-queue");

--- a/tdrive/backend/node/src/core/platform/framework/utils/component-utils.ts
+++ b/tdrive/backend/node/src/core/platform/framework/utils/component-utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types */
 import {
-  logger,
+  platformLogger,
   TdriveComponent,
   TdriveContext,
   TdriveServiceFactory,
@@ -28,7 +28,7 @@ export async function buildDependenciesTree(
             `The component dependency ${dependencyName} has not been found for component ${name}`,
           );
         } else {
-          logger.warn(
+          platformLogger.warn(
             `(warning) The component dependency ${dependencyName} has not been found for component ${name} it will be imported asynchronously`,
           );
 
@@ -99,10 +99,10 @@ export async function switchComponentsToState(
   const states = [];
 
   for (const [name, component] of components) {
-    logger.info(`Asking for ${state} on ${name} dependencies`);
+    platformLogger.info(`Asking for ${state} on ${name} dependencies`);
     states.push(component.getServiceInstance().state);
     await component.switchToState(state);
   }
 
-  logger.info(`All components are now in ${state} state`);
+  platformLogger.info(`All components are now in ${state} state`);
 }

--- a/tdrive/backend/node/src/core/platform/framework/utils/loader.ts
+++ b/tdrive/backend/node/src/core/platform/framework/utils/loader.ts
@@ -1,4 +1,4 @@
-import { logger } from "../logger";
+import { platformLogger } from "../logger";
 import fs from "fs";
 
 export class Loader {
@@ -14,7 +14,7 @@ export class Loader {
           try {
             return await import(modulePath);
           } catch (err) {
-            logger.debug(
+            platformLogger.debug(
               { err },
               `${modulePath} can not be loaded (file was found but we were unable to import the module)`,
             );
@@ -28,7 +28,9 @@ export class Loader {
     if (!classes || !classes.length) {
       modulesPaths.map(modulePath => {
         if (fs.existsSync(modulePath)) {
-          logger.debug(`${modulePath} content was: [${fs.readdirSync(modulePath).join(", ")}]`);
+          platformLogger.debug(
+            `${modulePath} content was: [${fs.readdirSync(modulePath).join(", ")}]`,
+          );
         }
       });
       throw new Error(
@@ -38,7 +40,7 @@ export class Loader {
       );
     }
 
-    logger.debug(`Loaded ${componentName}`);
+    platformLogger.debug(`Loaded ${componentName}`);
 
     return classes[0].default;
   }

--- a/tdrive/backend/node/src/core/platform/services/message-queue/processor.ts
+++ b/tdrive/backend/node/src/core/platform/services/message-queue/processor.ts
@@ -1,4 +1,4 @@
-import { logger } from "../../framework";
+import { messageQueueLogger } from "../../framework";
 import { MessageQueueHandler, MessageQueueServiceAPI, MessageQueueServiceProcessor } from "./api";
 
 const LOG_PREFIX = "service.message-queue.Processor";
@@ -20,9 +20,9 @@ export class Processor {
     this.started = true;
     await Promise.all(
       Array.from(this.registry.processors.keys()).map(async name => {
-        logger.info(`${LOG_PREFIX} - Starting notification processor ${name}`);
+        messageQueueLogger.info(`${LOG_PREFIX} - Starting notification processor ${name}`);
         await this.registry.processors.get(name)?.init();
-        logger.info(`${LOG_PREFIX} - notification processor ${name} is started`);
+        messageQueueLogger.info(`${LOG_PREFIX} - notification processor ${name} is started`);
       }),
     );
   }
@@ -41,7 +41,7 @@ export class Processor {
       throw new Error(`${LOG_PREFIX} - Can not add null handler`);
     }
 
-    logger.info(`${LOG_PREFIX} - Adding message-queue handler ${handler.name}`);
+    messageQueueLogger.info(`${LOG_PREFIX} - Adding message-queue handler ${handler.name}`);
     this.registry.register(handler);
 
     if (this.started) {
@@ -50,17 +50,17 @@ export class Processor {
   }
 
   async startHandler(name: string): Promise<void> {
-    logger.info(`${LOG_PREFIX} - Starting message-queue handler ${name}`);
+    messageQueueLogger.info(`${LOG_PREFIX} - Starting message-queue handler ${name}`);
     await this.registry.processors.get(name)?.init();
   }
 
   stopHandler(name: string): void {
-    logger.info(`${LOG_PREFIX} - Stopping message-queue handler ${name}`);
+    messageQueueLogger.info(`${LOG_PREFIX} - Stopping message-queue handler ${name}`);
     this.registry.processors.get(name)?.stop();
   }
 
   removeHandler(name: string): void {
-    logger.info(`${LOG_PREFIX} - Removing message-queue handler ${name}`);
+    messageQueueLogger.info(`${LOG_PREFIX} - Removing message-queue handler ${name}`);
     this.stopHandler(name);
     this.registry.processors.delete(name);
   }


### PR DESCRIPTION
Move platform and message queue logging to their own loggers for better filtering in dev