### PR TITLE
🐛 [in brackets] back: immediately start streaming downloading of zip #783

### DIFF
--- a/tdrive/backend/node/src/services/documents/utils.ts
+++ b/tdrive/backend/node/src/services/documents/utils.ts
@@ -345,6 +345,9 @@ export const addDriveItemToArchive = async (
   id: string,
   entity: DriveFile | null,
   archive: archiver.Archiver,
+  beginArchiveTransmit:
+    | "ONLY_SET_THIS_VALUE_IF_ALREADY_CALLED"
+    | ((archive: archiver.Archiver) => void),
   repository: Repository<DriveFile>,
   context: CompanyExecutionContext,
   prefix?: string,
@@ -368,6 +371,10 @@ export const addDriveItemToArchive = async (
     }
 
     archive.append(file.file, { name: item.name, prefix: prefix ?? "" });
+    if (beginArchiveTransmit !== "ONLY_SET_THIS_VALUE_IF_ALREADY_CALLED") {
+      beginArchiveTransmit(archive);
+      beginArchiveTransmit = "ONLY_SET_THIS_VALUE_IF_ALREADY_CALLED";
+    }
     return;
   } else {
     let nextPage = "";
@@ -384,6 +391,7 @@ export const addDriveItemToArchive = async (
           child.id,
           child,
           archive,
+          beginArchiveTransmit,
           repository,
           context,
           `${prefix || ""}${item.name}/`,

--- a/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
+++ b/tdrive/backend/node/src/services/documents/web/controllers/documents.ts
@@ -551,21 +551,21 @@ export class DocumentsController {
       const archiveOrFile = await globalResolver.services.documents.documents.download(
         id,
         versionId,
+        archive => {
+          archive.on("finish", () => {
+            response.status(200);
+          });
+
+          archive.on("error", () => {
+            response.internalServerError();
+          });
+
+          archive.pipe(response.raw);
+        },
         context,
       );
 
       if (archiveOrFile.archive) {
-        const archive = archiveOrFile.archive;
-
-        archive.on("finish", () => {
-          response.status(200);
-        });
-
-        archive.on("error", () => {
-          response.internalServerError();
-        });
-
-        archive.pipe(response.raw);
         return response;
       } else if (archiveOrFile.file) {
         const data = archiveOrFile.file;
@@ -623,21 +623,26 @@ export class DocumentsController {
     }
 
     try {
-      const archive = await globalResolver.services.documents.documents.createZip(ids, context);
-      reply.raw.setHeader(
-        "content-disposition",
-        formatAttachmentContentDispositionHeader("twake_drive.zip"),
+      await globalResolver.services.documents.documents.createZip(
+        ids,
+        archive => {
+          reply.raw.setHeader(
+            "content-disposition",
+            formatAttachmentContentDispositionHeader("twake_drive.zip"),
+          );
+
+          archive.on("finish", () => {
+            reply.status(200);
+          });
+
+          archive.on("error", () => {
+            reply.internalServerError();
+          });
+
+          archive.pipe(reply.raw);
+        },
+        context,
       );
-
-      archive.on("finish", () => {
-        reply.status(200);
-      });
-
-      archive.on("error", () => {
-        reply.internalServerError();
-      });
-
-      archive.pipe(reply.raw);
 
       return reply;
     } catch (error) {


### PR DESCRIPTION
When downloading a folder with a great many entries below, time to first byte can cause a tcp disconnection for timeout by a reverse proxy, this starts the download asap, and ignores unreadable entries because of AV or rights. It tries to generate a valid zip even if some entries are missing for those reasons