### PR TITLE
Fix password visible as plaintext on shared link input

### DIFF
--- a/tdrive/frontend/src/app/views/client/body/drive/modals/public-link/password-editor-row.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/modals/public-link/password-editor-row.tsx
@@ -100,6 +100,7 @@ return <>
       suffix={isEditingPassword
         ? <>
             <Input
+              type="password"
               inputRef={inputRef}
               disabled={disabled}
               className="max-w-xs mr-4 mt-1"

--- a/tdrive/frontend/src/app/views/client/body/drive/shared.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/shared.tsx
@@ -157,6 +157,7 @@ const AccessChecker = ({
           <br />
           <div className="flex items-center mt-2">
             <Input
+              type="password"
               theme="outline"
               placeholder="Password"
               className="-mr-px rounded-r-none border-r-none"


### PR DESCRIPTION
## Summary

- Fixes #490 — password input for shared file links uses `type="text"`, exposing the password in plaintext
- Added `type="password"` to the `<Input>` on the shared link access page (`shared.tsx`) so visitors' passwords are masked
- Also added `type="password"` to the password editor input in the public link settings modal (`password-editor-row.tsx`) for consistency

## Test plan

- [ ] Open a password-protected public shared link in the browser
- [ ] Verify the password input field masks characters (shows dots instead of plaintext)
- [ ] Open the public link settings modal and edit a password — verify the edit field also masks characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)