### PR TITLE
Fix NaN date display in file browser (#756)

### DIFF
--- a/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
+++ b/tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx
@@ -57,7 +57,7 @@ export default (props: { driveItem: DriveItem & { user?: UserType } }) => {
           />
         </Text.Base>
         <Text.Info className="block testid:drive-item-file">
-          {extension?.toLocaleUpperCase()} • {formatDate(parseInt(file?.last_modified))} •{' '}
+          {extension?.toLocaleUpperCase()} • {formatDate(file?.last_modified ? parseInt(file.last_modified) : undefined)} •{' '}
           {formatSize(file?.size)}
         </Text.Info>
         <ResultContext user={file.user} testClassId="search-result-context" />

--- a/tdrive/frontend/src/app/features/global/utils/Numbers.ts
+++ b/tdrive/frontend/src/app/features/global/utils/Numbers.ts
@@ -106,13 +106,15 @@ export default class Numbers {
 }
 
 export const formatTime = (
-  time: number | string,
+  time?: number | string | null,
   locale?: string,
   options: { keepTime?: boolean; keepSeconds?: boolean; keepDate?: boolean } = {
     keepTime: true,
   }
 ) => {
+  if (time === null || time === undefined) return '-';
   time = new Date(time).getTime();
+  if (isNaN(time)) return '-';
   locale = locale || navigator.language;
   const now = Date.now();
   const year = new Date(time).getFullYear();
@@ -127,8 +129,10 @@ export const formatTime = (
     second: options?.keepSeconds ? "numeric" : undefined,
   }).format(new Date(time));
 };
-export const formatDateShort = (time : number | string) => {
+export const formatDateShort = (time?: number | string | null) => {
+  if (time === null || time === undefined) return '-';
   const date = new Date(time);
+  if (isNaN(date.getTime())) return '-';
   const padZero = (num :number) => num.toString().padStart(2, '0');
 
   const month = padZero(date.getMonth() + 1); // Months are zero-indexed

--- a/tdrive/frontend/src/app/features/global/utils/format-date.ts
+++ b/tdrive/frontend/src/app/features/global/utils/format-date.ts
@@ -1,14 +1,15 @@
 export const formatDate = (date?: number) => {
-  return date
-    ? new Intl.DateTimeFormat(navigator.languages[0], {
-        year: 'numeric',
-        month: 'numeric',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-        second: 'numeric',
-        weekday: 'short',
-        hour12: false,
-      }).format(new Date(date))
-    : '';
+  if (date === null || date === undefined || isNaN(date)) return '-';
+  const d = new Date(date);
+  if (isNaN(d.getTime())) return '-';
+  return new Intl.DateTimeFormat(navigator.languages[0], {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    weekday: 'short',
+    hour12: false,
+  }).format(d);
 };

--- a/tdrive/frontend/src/app/views/client/body/drive/modals/versions/index.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/modals/versions/index.tsx
@@ -107,7 +107,7 @@ const VersionModalContent = ({ id }: { id: string }) => {
               <Base className="testid:name">{version.file_metadata.name}</Base>
             </div>
             <div className="shrink-0 ml-4">
-              <BaseSmall className="testid:date-added">{formatDate(version.date_added || 0)}</BaseSmall>
+              <BaseSmall className="testid:date-added">{formatDate(version.date_added)}</BaseSmall>
             </div>
             <div className="shrink-0 ml-4">
               <BaseSmall className="testid:file-size">{formatBytes(version.file_metadata.size || 0)}</BaseSmall>

--- a/tdrive/frontend/src/app/views/client/body/drive/shared-files-table.tsx
+++ b/tdrive/frontend/src/app/views/client/body/drive/shared-files-table.tsx
@@ -24,8 +24,11 @@ export const SharedFilesTable = () => {
   const buildFileContextMenu = useOnBuildFileContextMenu();
   const buildDateContextMenu = useOnBuildDateContextMenu();
 
-  const fileAddedDate = (timestamp: number) => {
-    const [formattedDate] = new Date(timestamp).toLocaleString().split(', ');
+  const fileAddedDate = (timestamp?: number | null) => {
+    if (timestamp === null || timestamp === undefined) return '-';
+    const date = new Date(timestamp);
+    if (isNaN(date.getTime())) return '-';
+    const [formattedDate] = date.toLocaleString().split(', ');
     return formattedDate;
   };
   return (


### PR DESCRIPTION
## Summary
- Add null/undefined/invalid date guards to all date formatting utilities (`formatDate`, `formatDateShort`, `formatTime`) so they return `"-"` instead of `"NaN"` when date values are missing or invalid
- Fix `parseInt(undefined)` producing `NaN` in the search result component's date display
- Fix the `fileAddedDate` helper in the shared files table to handle missing timestamps
- Remove misleading `|| 0` fallback in the versions modal that would display Unix epoch (Jan 1, 1970) for missing dates

## Root cause
When a drive item has no `date_added`, `last_modified`, or `added` timestamp (e.g. due to incomplete metadata), the date formatting functions receive `undefined` or `NaN`. JavaScript's `new Date(undefined)` produces an `Invalid Date` object, and calling `.getMonth()`, `.getDate()`, etc. on it returns `NaN`, which renders literally as "NaN" in the UI.

## Files changed
- `tdrive/frontend/src/app/features/global/utils/format-date.ts` — guard against null/undefined/NaN input
- `tdrive/frontend/src/app/features/global/utils/Numbers.ts` — guard `formatDateShort` and `formatTime`
- `tdrive/frontend/src/app/components/search-popup/parts/drive-item-result.tsx` — avoid `parseInt(undefined)`
- `tdrive/frontend/src/app/views/client/body/drive/shared-files-table.tsx` — guard `fileAddedDate`
- `tdrive/frontend/src/app/views/client/body/drive/modals/versions/index.tsx` — remove `|| 0` epoch fallback

## Test plan
- [ ] Open a folder containing items with missing `date_added` in `last_version_cache` — verify "-" displays instead of "NaN"
- [ ] Open file preview for an item with no `added` or `date_added` — verify "-" displays in the info bar
- [ ] Search for files — verify search results show "-" for items with missing `last_modified`
- [ ] Open the "Shared with me" view — verify shared date column shows "-" for items with missing `added`
- [ ] Open the versions modal — verify "-" for versions with no `date_added` (instead of epoch date)
- [ ] Verify that items with valid dates still display correctly

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)