### PR TITLE
fix(i18n): resolve sidebar language mixup on first load

### DIFF
--- a/tdrive/frontend/src/app/views/client/side-bar/actions.tsx
+++ b/tdrive/frontend/src/app/views/client/side-bar/actions.tsx
@@ -12,7 +12,7 @@ import { ConfirmDeleteModalAtom } from '../body/drive/modals/confirm-delete';
 import { CreateModal, CreateModalAtom } from '../body/drive/modals/create';
 import { UploadModelAtom, UploadModal } from '../body/drive/modals/upload'
 import { Button } from '@atoms/button/button';
-import Languages from "features/global/services/languages-service";
+import { useTranslation } from 'react-i18next';
 import { useCurrentUser } from 'app/features/users/hooks/use-current-user';
 import useRouteState from 'app/features/router/hooks/use-route-state';
 
@@ -96,6 +96,7 @@ export const CreateModalWithUploadZones = ({ initialParentId }: { initialParentI
 };
 
 export default () => {
+  const { t } = useTranslation();
   const { user } = useCurrentUser();
   const { viewId, dirId } = useRouteState();
   const [ parentId ] = useRecoilState(DriveCurrentFolderAtom({ initialFolderId: dirId || viewId || 'user_'+user?.id  }));
@@ -139,7 +140,7 @@ export default () => {
                 disabled={!(trashChildren.length > 0)}
                 testClassId="create-modal-in-trash-button-empty-trash"
               >
-                <TruckIcon className="w-5 h-5 mr-2" /> { Languages.t('components.side_menu.buttons.empty_trash') }
+                <TruckIcon className="w-5 h-5 mr-2" /> { t('components.side_menu.buttons.empty_trash') }
               </Button>
             </>
           )}
@@ -173,7 +174,7 @@ export default () => {
                 style={{ boxShadow: '0 0 10px 0 rgba(0, 122, 255, 0.5)' }}
                 testClassId="button-upload"
               >
-                <UploadIcon className="w-5 h-5 mr-2" /> {Languages.t('components.side_menu.buttons.upload')}
+                <UploadIcon className="w-5 h-5 mr-2" /> {t('components.side_menu.buttons.upload')}
               </Button>
               <Button
                 onClick={() => openItemModal()}
@@ -183,7 +184,7 @@ export default () => {
                 className="w-full mb-2 justify-center"
                 testClassId="button-open-create-modal"
               >
-                <PlusIcon className="w-5 h-5 mr-2" /> {Languages.t('components.side_menu.buttons.create')}
+                <PlusIcon className="w-5 h-5 mr-2" /> {t('components.side_menu.buttons.create')}
               </Button>
             </>
           )}

--- a/tdrive/frontend/src/app/views/client/side-bar/index.tsx
+++ b/tdrive/frontend/src/app/views/client/side-bar/index.tsx
@@ -10,6 +10,7 @@ import {
   UserGroupIcon,
 } from '@heroicons/react/outline';
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import useRouterCompany from '@features/router/hooks/use-router-company';
 import { useCurrentUser } from 'app/features/users/hooks/use-current-user';
 import { useRecoilState } from 'recoil';
@@ -22,12 +23,12 @@ import DiskUsage from '../common/disk-usage';
 import Actions from './actions';
 import { useHistory } from 'react-router-dom';
 import RouterServices from '@features/router/services/router-service';
-import Languages from 'features/global/services/languages-service';
 import FeatureTogglesService, {
   FeatureNames,
 } from '@features/global/services/feature-toggles-service';
 
 export default () => {
+  const { t } = useTranslation();
   const history = useHistory();
   const { user } = useCurrentUser();
   const company = useRouterCompany();
@@ -102,7 +103,7 @@ export default () => {
           }
           testClassId="sidebar-menu-my-drive"
         >
-          <UserIcon className="w-5 h-5 mr-4" /> {Languages.t('components.side_menu.my_drive')}
+          <UserIcon className="w-5 h-5 mr-4" /> {t('components.side_menu.my_drive')}
         </Button>
         {FeatureTogglesService.isActiveFeatureName(FeatureNames.COMPANY_SHARED_DRIVE) && (
           <Button
@@ -124,7 +125,7 @@ export default () => {
             }
             testClassId="sidebar-menu-shared-drive"
           >
-            <CloudIcon className="w-5 h-5 mr-4" /> {Languages.t('components.side_menu.home')}
+            <CloudIcon className="w-5 h-5 mr-4" /> {t('components.side_menu.home')}
           </Button>
         )}
         {FeatureTogglesService.isActiveFeatureName(FeatureNames.COMPANY_MANAGE_ACCESS) && (
@@ -149,7 +150,7 @@ export default () => {
             testClassId="sidebar-menu-share-with-me"
           >
             <UserGroupIcon className="w-5 h-5 mr-4" />{' '}
-            {Languages.t('components.side_menu.shared_with_me')}
+            {t('components.side_menu.shared_with_me')}
           </Button>
         )}
         {false && (
@@ -188,7 +189,7 @@ export default () => {
           testClassId="sidebar-menu-trash"
         >
           <TrashIcon className="w-5 h-5 mr-4 text-rose-500" />{' '}
-          {Languages.t('components.side_menu.trash')}
+          {t('components.side_menu.trash')}
         </Button>
 
         {false && (


### PR DESCRIPTION
## Summary

Fixes #828 — French/English language mixup in the sidebar on first load.

- **Root cause**: The sidebar components (`side-bar/index.tsx` and `side-bar/actions.tsx`) used `Languages.t()` for translations — a non-reactive wrapper around `i18n.t()` that reads the current locale at render time but does not subscribe to language change events. On first load, `i18next-browser-languagedetector` picks up the browser locale (often `fr`), and the sidebar renders immediately with French strings. The user's actual language preference is loaded asynchronously from the backend and applied via `Languages.setLanguage()`, but the sidebar never re-renders because `Languages.t()` has no reactivity mechanism.
- **Fix**: Replace `Languages.t()` with react-i18next's `useTranslation()` hook, which subscribes to i18next language change events and triggers a re-render when the locale updates. This ensures the sidebar always reflects the resolved language, whether it comes from browser detection, the backend user preference, or a manual toggle.

### Files changed
- `tdrive/frontend/src/app/views/client/side-bar/index.tsx` — use `useTranslation` hook, remove `Languages` import
- `tdrive/frontend/src/app/views/client/side-bar/actions.tsx` — use `useTranslation` hook, remove `Languages` import

## Test plan

- [ ] Set user language preference to English in account settings
- [ ] Hard-refresh the app (Ctrl+Shift+R) with browser language set to French
- [ ] Verify sidebar shows "My Drive", "Trash", "Upload", "Create" (English) on first load — not "Mon disque"
- [ ] Toggle language to French and back to English in settings; verify sidebar updates correctly
- [ ] Verify no console errors related to i18n or missing translation keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)