### PR TITLE
fix(postgres): handle empty SET clause in upsertOne

### DIFF
--- a/tdrive/backend/node/src/core/platform/services/database/services/orm/connectors/postgres/postgres-query-builder.ts
+++ b/tdrive/backend/node/src/core/platform/services/database/services/orm/connectors/postgres/postgres-query-builder.ts
@@ -178,6 +178,27 @@ export class PostgresQueryBuilder {
     return [query, fields.map(f => f[1])];
   }
 
+  buildInsertOnConflictDoNothing<Entity>(entity: Entity): Query {
+    const { columnsDefinition, entityDefinition } = getEntityDefinition(entity);
+
+    const fields = Object.keys(columnsDefinition)
+      .filter(key => entity[columnsDefinition[key].nodename] !== undefined)
+      .map(key => this.toValueKeyDBStringPairFromEntity(entity, columnsDefinition, key));
+    const query = `INSERT INTO "${entityDefinition.name}" (${fields.map(e => e[0]).join(", ")})
+              VALUES (${fields.map((e, idx) => `$${idx + 1}`).join(", ")})
+              ON CONFLICT DO NOTHING`;
+    return [query, fields.map(f => f[1])];
+  }
+
+  hasNonPrimaryKeyFields<Entity>(entity: Entity): boolean {
+    const { columnsDefinition, entityDefinition } = getEntityDefinition(entity);
+    const primaryKey = unwrapPrimarykey(entityDefinition);
+
+    return Object.keys(columnsDefinition)
+      .filter(key => primaryKey.indexOf(key) === -1)
+      .some(key => entity[columnsDefinition[key].nodename] !== undefined);
+  }
+
   private buildWhereClause(startIndex: number, where: [string, any[]][]): Query {
     const equalsOrIs = ([key, value]) =>
       [key, value === null ? "IS" : "=", value === null ? "NULL" : `$${startIndex++}`].join(" ");

--- a/tdrive/backend/node/src/core/platform/services/database/services/orm/connectors/postgres/postgres.ts
+++ b/tdrive/backend/node/src/core/platform/services/database/services/orm/connectors/postgres/postgres.ts
@@ -331,6 +331,14 @@ export class PostgresConnector extends AbstractConnector<PostgresConnectionOptio
       const query = this.queryBuilder.buildInsert(entity);
       return this.execute(query);
     } else if (_options.action == "UPDATE") {
+      // When the entity only has primary key fields (no non-PK fields to update),
+      // buildUpdate would generate an invalid empty SET clause (e.g. UPDATE ... SET WHERE ...).
+      // In this case, skip the UPDATE and just ensure the row exists via INSERT ON CONFLICT DO NOTHING.
+      if (!this.queryBuilder.hasNonPrimaryKeyFields(entity)) {
+        const query = this.queryBuilder.buildInsertOnConflictDoNothing(entity);
+        await this.execute(query);
+        return true;
+      }
       if (!(await this.execute(this.queryBuilder.buildUpdate(entity)))) {
         return this.execute(this.queryBuilder.buildInsert(entity));
       }


### PR DESCRIPTION
## Summary
- Fixes the SSO upsert constraint issue where `upsertOne()` generates invalid SQL (`UPDATE ... SET WHERE ...`) when an entity has only primary key fields and no non-PK fields to update
- Adds `hasNonPrimaryKeyFields()` check to detect the empty-SET case before attempting an UPDATE
- Adds `buildInsertOnConflictDoNothing()` query builder method to safely ensure the row exists without duplicate key violations

## Root Cause
When syncing SSO user data, the `external_user_repository` entity sometimes has only its composite primary key (`service_id`, `external_id`, `user_id`) set with no additional fields. `buildUpdate()` produces an empty SET clause, causing PostgreSQL error 42601. The fallback `buildInsert()` then fails with a duplicate key violation since the row already exists.

## Fix
When no non-PK fields are present, skip the UPDATE entirely and use `INSERT ... ON CONFLICT DO NOTHING`. If the row already exists, the INSERT is a no-op and returns `true`. If it doesn't exist, it gets inserted.

Closes #768

## Test plan
- [ ] Verify SSO login flow with an existing external user (triggers upsert with PK-only entity)
- [ ] Verify SSO login flow with a new external user (triggers normal insert path)
- [ ] Verify normal entity updates with non-PK fields still work via the UPDATE path

🤖 Generated with [Claude Code](https://claude.com/claude-code)