### PR TITLE
fix: restrict document search to current user's files to prevent MongoDB OOM

### DIFF
--- a/tdrive/backend/node/src/services/documents/services/index.ts
+++ b/tdrive/backend/node/src/services/documents/services/index.ts
@@ -1641,9 +1641,10 @@ export class DocumentsService {
           $in: [
             ...(options.onlyDirectlyShared
               ? [["access_entities", [context.user.id]] as inType]
-              : []),
+              : options.onlyUploadedNotByMe
+              ? []
+              : [["creator", [options.creator || context.user.id]] as inType]),
             ...(options.company_id ? [["company_id", [options.company_id]] as inType] : []),
-            ...(options.creator ? [["creator", [options.creator]] as inType] : []),
             ...(options.mime_type
               ? [
                   [
@@ -1693,6 +1694,8 @@ export class DocumentsService {
       // Check access permissions
       if (!options.onlyDirectlyShared) {
         filteredResult = await this.filter(filteredResult, async item => {
+          // Creator always has access to their own documents — skip the recursive parent traversal
+          if (item.creator === context.user.id) return !item.is_in_trash;
           try {
             return (
               !item.is_in_trash &&

--- a/tdrive/backend/node/test/e2e/documents/documents-search.spec.ts
+++ b/tdrive/backend/node/test/e2e/documents/documents-search.spec.ts
@@ -87,12 +87,11 @@ describe("the Drive Search feature", () => {
   });
 
 
-  it("did search for an item and check that all the fields for 'shared_with_me' view", async () => {
-    // jest.setTimeout(20000);
-    //when:: user search for a doc
+  it.skip("did search for an item and check that all the fields for 'shared_with_me' view", async () => {
+    // Skipped: search is now restricted to documents owned by the current user (creator filter).
+    // Files from other users no longer appear in general search results.
+    // Use the shared_with_me browse endpoint for cross-user document discovery.
     const searchResponse = await userOne.searchDocument({ view: "shared_with_me" });
-
-    //then::
     expect(searchResponse.entities?.length).toEqual(UserApi.ALL_FILES.length * 3);
     const docs = searchResponse.entities.filter(e => e.id === uploadedByUserOne[0].id)
     expect(docs.length).toEqual(1)


### PR DESCRIPTION
## What

Two changes, ~10 lines:

1. Search query always filters `creator == current_user` at MongoDB level. Previously optional — without it, a search scanned the entire document collection.
2. Results where `item.creator === context.user.id` skip `checkAccess()` entirely. Creator always has access to their own files. No database round-trip needed.

One e2e test is skipped: the one asserting other users' files appear in general search results, because they no longer do.

---

## Why this is the right call

The search endpoint could OOM the MongoDB cluster — not just for Twake Drive, but **for every application sharing the instance**.

What happened on each search request:

1. A `do-while` loop paginated through the entire `search__drive_files` collection until it accumulated enough results passing access checks.
2. Per page of 100 docs: `SearchRepository` fires **100 sequential `findOne()` calls** on `drive_files` to hydrate full documents.
3. Then `Promise.all` fires **100 concurrent `checkAccess()` calls**, each recursively walking the parent folder hierarchy — one `findOne()` per folder level up to the root.
4. With sparse access (user owns 2% of matching docs), the loop ran 50 times: ~201 MongoDB queries × 50 iterations = **10 000+ MongoDB queries per search request**, all holding results in memory simultaneously.

MongoDB had to keep the working set for all of this in RAM. One user searching a common word was enough to OOM the database and take down every other tenant on the cluster.

The correct long-term fix is to denormalize effective access into the search index. That requires a data migration and architectural work — not appropriate here.

**This fix eliminates the OOM with ~10 lines of code and zero migration**, at the cost of not returning other users' shared files in general search results. The `shared_with_me` browse endpoint remains fully functional for cross-user discovery and is the semantically correct place for that anyway.

The tradeoff is deliberate. The alternative is leaving a loaded gun pointed at a shared database cluster.

---

## Known remaining issues (not addressed here, not stability blockers)

- `SearchRepository` hydrates documents with sequential `findOne()` — should be a batched `find({ id: { $in: [...] } })`.
- Pagination uses `skip()` which is O(n).
- No hard cap on client-requested page size.

Co-Authored-By: Claude <claude@anthropic.com>